### PR TITLE
Avoid deprecated pdoTools logs when its used, fix typo in sizes example

### DIFF
--- a/core/components/imagecropper/lexicon/en/clientsettings.inc.php
+++ b/core/components/imagecropper/lexicon/en/clientsettings.inc.php
@@ -9,7 +9,7 @@
 $_lang['clientsettings.imagecropper.name']                      = 'Image crop';
 
 $_lang['clientsettings.imagecropper.label_sizes']               = 'Crops';
-$_lang['clientsettings.imagecropper.label_sizes_desc']          = 'A defined JSON for the crops, for example {"desktop": {"name": "Desktop", "size": "1000x500"}, "mobile": {"name": "Mobiel", "size": "768x500"}}.';
+$_lang['clientsettings.imagecropper.label_sizes_desc']          = 'A defined JSON for the crops, for example {"desktop": {"name": "Desktop", "size": "1000x500"}, "mobile": {"name": "Mobile", "size": "768x500"}}.';
 $_lang['clientsettings.imagecropper.label_previews']            = 'Show preview';
 $_lang['clientsettings.imagecropper.label_previews_desc']       = 'Display the previews of the crops under the field.';
 

--- a/core/components/imagecropper/model/imagecropper/imagecroppersnippets.class.php
+++ b/core/components/imagecropper/model/imagecropper/imagecroppersnippets.class.php
@@ -72,14 +72,13 @@ class ImagecropperSnippets extends ImageCropper
         if (class_exists('pdoTools') && $pdo = $this->modx->getService('pdoTools')) {
             if ((bool) $this->getProperty('usePdoTools')) {
                 if ((bool) $this->getProperty('usePdoElementsPath')) {
-                    $elementsPath = $this->modx->getOption('pdotools_elements_path');
+                    return $pdo->getChunk($name, $properties);
                 } else {
                     $elementsPath = $this->getProperty('elementsPath', $this->config['core_path']);
+                    return $pdo->getChunk($name, array_merge([
+                        'elementsPath' => $elementsPath
+                    ], $properties));//pdoTools deprecated in 2.13.2-pl param 'elementsPath' throws MODX log errors but for BC this logic kept here, may be need refactor to setOption
                 }
-
-                return $pdo->getChunk($name, array_merge([
-                    'elementsPath' => $elementsPath
-                ], $properties));
             }
         }
 


### PR DESCRIPTION
Relate to https://github.com/modx-pro/pdoTools/issues/339 — pdoTools deprecated in 2.13.2-pl param 'elementsPath' throws MODX log errors but for BC this logic kept for standart imageCropper's elements path.

May be need additional refactor bottom condition (after else) to setOption for 'pdotools_elements_path' system setting to set standart imageCropper's path and then this option automatically will be used by pdoTools.

This update for MODX2 version